### PR TITLE
Fix CI PHPUnit: DB host override and Vite stub

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,19 +9,20 @@
     </testsuite>
   </testsuites>
   <php>
-    <server name="APP_ENV" value="testing"/>
-    <server name="BCRYPT_ROUNDS" value="4"/>
-    <server name="CACHE_DRIVER" value="array"/>
-    <server name="DB_CONNECTION" value="mysql"/>
-    <server name="DB_HOST" value="mysql"/>
-    <server name="DB_PORT" value="3306"/>
-    <server name="DB_DATABASE" value="firecrew_test"/>
-    <server name="DB_USERNAME" value="sail"/>
-    <server name="DB_PASSWORD" value="password"/>
-    <server name="MAIL_MAILER" value="array"/>
-    <server name="QUEUE_CONNECTION" value="sync"/>
-    <server name="SESSION_DRIVER" value="array"/>
-    <server name="TELESCOPE_ENABLED" value="false"/>
+    <!-- <env> (not <server>) lets CI override Sail defaults without force="true". -->
+    <env name="APP_ENV" value="testing"/>
+    <env name="BCRYPT_ROUNDS" value="4"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="DB_CONNECTION" value="mysql"/>
+    <env name="DB_HOST" value="mysql"/>
+    <env name="DB_PORT" value="3306"/>
+    <env name="DB_DATABASE" value="firecrew_test"/>
+    <env name="DB_USERNAME" value="sail"/>
+    <env name="DB_PASSWORD" value="password"/>
+    <env name="MAIL_MAILER" value="array"/>
+    <env name="QUEUE_CONNECTION" value="sync"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="TELESCOPE_ENABLED" value="false"/>
   </php>
   <source>
     <include>

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,11 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Feature tests may render Blade layouts that call @vite; CI does not build assets.
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
## Summary
- Switch `phpunit.xml` from `<server>` to `<env>` so CI's `DB_HOST=127.0.0.1` / `root` credentials are not overwritten by Sail defaults (`mysql` / `sail`)
- Call `withoutVite()` in the base test case so feature tests can render Blade layouts without a Vite manifest in CI
- Remove an unused `RefreshDatabase` import from `ExampleTest`

## Test plan
- [x] `./vendor/bin/sail artisan test` — 11 passed locally
- [ ] Confirm the `Run PHPUnit` job on this PR (or after merge to main) connects to MySQL and passes

Made with [Cursor](https://cursor.com)