### PR TITLE
Add new aircraft assignment for "Unavailable: Mechanical"

### DIFF
--- a/resources/js/components/StatusMap/AircraftDetailsContent.tsx
+++ b/resources/js/components/StatusMap/AircraftDetailsContent.tsx
@@ -8,10 +8,12 @@ import {
     Title,
 } from '@mantine/core';
 import type { ReactNode } from 'react';
+import MechanicalProblemLabel from '../StatusSummaryTable/MechanicalProblemLabel';
 import {
     getMakeModelLabel,
     getRangeStatuteMiles,
     HelicopterProps,
+    isMechanicalUnavailable,
 } from './Helicopter';
 
 export type AircraftDetailsContentProps = {
@@ -47,14 +49,23 @@ export const AircraftDetailsContent = ({
     onZoomToRange,
 }: AircraftDetailsContentProps) => {
     const range = getRangeStatuteMiles(helicopter.makeModel);
+    const mechanical = isMechanicalUnavailable(helicopter);
 
     return (
         <Stack gap="md" h="100%">
             {withHeader && (
                 <Group justify="space-between" align="flex-start" wrap="nowrap">
-                    <Title order={4} m={0}>
-                        {aircraftDetailsTitle(helicopter)}
-                    </Title>
+                    <Group
+                        gap="sm"
+                        wrap="nowrap"
+                        align="center"
+                        style={{ minWidth: 0 }}
+                    >
+                        <Title order={4} m={0}>
+                            {aircraftDetailsTitle(helicopter)}
+                        </Title>
+                        {mechanical ? <MechanicalProblemLabel /> : null}
+                    </Group>
                     {onClose && (
                         <CloseButton
                             aria-label="Close aircraft details"

--- a/resources/js/components/StatusMap/AircraftDetailsDrawer.tsx
+++ b/resources/js/components/StatusMap/AircraftDetailsDrawer.tsx
@@ -1,5 +1,6 @@
-import { Drawer } from '@mantine/core';
+import { Drawer, Group } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
+import MechanicalProblemLabel from '../StatusSummaryTable/MechanicalProblemLabel';
 import {
     AircraftDetailsContent,
     aircraftDetailsTitle,
@@ -8,7 +9,7 @@ import {
     DESKTOP_DRAWER_WIDTH_PX,
     MOBILE_DRAWER_SIZE,
 } from './detailsLayout';
-import { HelicopterProps } from './Helicopter';
+import { HelicopterProps, isMechanicalUnavailable } from './Helicopter';
 
 export type AircraftDetailsDrawerProps = {
     helicopter: HelicopterProps | null;
@@ -28,6 +29,8 @@ export const AircraftDetailsDrawer = ({
     onZoomToRange,
 }: AircraftDetailsDrawerProps) => {
     const isDesktop = useMediaQuery('(min-width: 62em)');
+    const mechanical =
+        helicopter !== null && isMechanicalUnavailable(helicopter);
 
     return (
         <Drawer
@@ -40,7 +43,16 @@ export const AircraftDetailsDrawer = ({
             lockScroll={false}
             trapFocus={false}
             closeOnClickOutside={false}
-            title={helicopter ? aircraftDetailsTitle(helicopter) : 'Aircraft'}
+            title={
+                helicopter ? (
+                    <Group gap="sm" wrap="nowrap" align="center">
+                        <span>{aircraftDetailsTitle(helicopter)}</span>
+                        {mechanical ? <MechanicalProblemLabel /> : null}
+                    </Group>
+                ) : (
+                    'Aircraft'
+                )
+            }
             styles={{
                 content: {
                     borderLeft: isDesktop

--- a/resources/js/components/StatusMap/Helicopter.ts
+++ b/resources/js/components/StatusMap/Helicopter.ts
@@ -43,6 +43,13 @@ export type HelicopterProps = {
     updatedAt: Date;
 };
 
+/** Assignment value that indicates an aircraft has a mechanical problem. */
+export const MECHANICAL_ASSIGNMENT = 'Unavailable: Mechanical';
+
+export const isMechanicalUnavailable = (
+    helicopter: Pick<HelicopterProps, 'assignedFireName'>
+): boolean => helicopter.assignedFireName === MECHANICAL_ASSIGNMENT;
+
 const FRESH_MS = 18 * 60 * 60 * 1000;
 const ICON_PATH = '/images/symbols';
 

--- a/resources/js/components/StatusMap/HelicopterIcon.tsx
+++ b/resources/js/components/StatusMap/HelicopterIcon.tsx
@@ -1,4 +1,4 @@
-import type { ImgHTMLAttributes } from 'react';
+import type { ImgHTMLAttributes, CSSProperties } from 'react';
 
 export type HelicopterIconState = 'fresh' | 'stale';
 
@@ -10,6 +10,8 @@ export type HelicopterIconProps = Omit<
     state?: HelicopterIconState;
     /** Convenience alias for `state={fresh ? 'fresh' : 'stale'}`. */
     fresh?: boolean;
+    /** When true, draw a red equilateral triangle stroke around the icon. */
+    mechanical?: boolean;
 };
 
 const ICON_PATH = '/images/symbols';
@@ -25,13 +27,18 @@ export function getHelicopterIconSrc(
     return HELICOPTER_ICON_URLS[state];
 }
 
+/** Equilateral triangle points centered in a 100×100 viewBox (tip up). */
+const MECHANICAL_TRIANGLE_POINTS = '50,4 96,88 4,88';
+
 /**
  * Top-down rappel helicopter marker. Uses transparent PNGs; switches
- * fresh vs stale via `state` / `fresh`.
+ * fresh vs stale via `state` / `fresh`. Optionally frames the icon with a
+ * red equilateral triangle when `mechanical` is true.
  */
 export function HelicopterIcon({
     state,
     fresh,
+    mechanical = false,
     width = 65,
     height = 65,
     alt,
@@ -41,7 +48,7 @@ export function HelicopterIcon({
     const resolved: HelicopterIconState =
         state ?? (fresh === false ? 'stale' : 'fresh');
 
-    return (
+    const img = (
         <img
             src={getHelicopterIconSrc(resolved)}
             alt={alt ?? ''}
@@ -51,5 +58,42 @@ export function HelicopterIcon({
             style={{ display: 'block', ...style }}
             {...rest}
         />
+    );
+
+    if (!mechanical) {
+        return img;
+    }
+
+    const wrapperStyle: CSSProperties = {
+        position: 'relative',
+        width,
+        height,
+        display: 'block',
+    };
+
+    return (
+        <div style={wrapperStyle}>
+            {img}
+            <svg
+                viewBox="0 0 100 100"
+                width={width}
+                height={height}
+                aria-hidden
+                style={{
+                    position: 'absolute',
+                    inset: 0,
+                    overflow: 'visible',
+                    pointerEvents: 'none',
+                }}
+            >
+                <polygon
+                    points={MECHANICAL_TRIANGLE_POINTS}
+                    fill="none"
+                    stroke="var(--mantine-color-red-9)"
+                    strokeWidth={5}
+                    strokeLinejoin="round"
+                />
+            </svg>
+        </div>
     );
 }

--- a/resources/js/components/StatusMap/Map.tsx
+++ b/resources/js/components/StatusMap/Map.tsx
@@ -4,6 +4,7 @@ import {
     getResponseRingColor,
     HelicopterProps,
     isHelicopterFresh,
+    isMechanicalUnavailable,
 } from './Helicopter';
 import { HelicopterIcon } from './HelicopterIcon';
 import {
@@ -220,6 +221,7 @@ const MapView = forwardRef<StatusMapHandle, StatusMapViewProps>(
                     {helicopters.map((helicopter) => {
                         const fresh = isHelicopterFresh(helicopter.updatedAt);
                         const selected = helicopter.id === selectedId;
+                        const mechanical = isMechanicalUnavailable(helicopter);
 
                         return (
                             <Marker
@@ -247,6 +249,7 @@ const MapView = forwardRef<StatusMapHandle, StatusMapViewProps>(
                                 >
                                     <HelicopterIcon
                                         fresh={fresh}
+                                        mechanical={mechanical}
                                         alt={helicopter.tailnumber}
                                         width={65}
                                         height={65}

--- a/resources/js/components/StatusSummaryTable/MechanicalProblemLabel.jsx
+++ b/resources/js/components/StatusSummaryTable/MechanicalProblemLabel.jsx
@@ -1,0 +1,62 @@
+import { Badge, Tooltip } from '@mantine/core';
+import { WrenchIcon } from '@phosphor-icons/react/dist/csr/Wrench';
+import PropTypes from 'prop-types';
+
+const ICON_SIZE_BY_BADGE = {
+    xs: 12,
+    sm: 14,
+    md: 16,
+    lg: 18,
+    xl: 20,
+};
+
+const BADGE_STYLES = {
+    root: {
+        '--badge-border-width': '2px',
+        // Darken the light-variant text/icon for WCAG AA contrast on red tint
+        '--badge-color': 'var(--mantine-color-red-9)',
+        '--badge-bg': 'var(--mantine-color-red-1)',
+    },
+    label: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        lineHeight: 1,
+    },
+};
+
+/**
+ * Compact badge indicating an aircraft has a mechanical problem.
+ */
+export function MechanicalProblemLabel({ size = 'lg', ...badgeProps }) {
+    const iconSize = ICON_SIZE_BY_BADGE[size] ?? ICON_SIZE_BY_BADGE.sm;
+
+    return (
+        <Tooltip label="Unavailable: Mechanical" withArrow openDelay={200}>
+            <Badge
+                variant="light"
+                color="red"
+                radius="sm"
+                size={size}
+                aria-label="Unavailable due to mechanical problem"
+                px={6}
+                bd="2px solid var(--badge-color)"
+                styles={BADGE_STYLES}
+                {...badgeProps}
+            >
+                <WrenchIcon
+                    size={iconSize}
+                    weight="bold"
+                    aria-hidden
+                    style={{ display: 'block' }}
+                />
+            </Badge>
+        </Tooltip>
+    );
+}
+
+MechanicalProblemLabel.propTypes = {
+    size: PropTypes.string,
+};
+
+export default MechanicalProblemLabel;

--- a/resources/js/components/StatusSummaryTable/NeedsUpdateLabel.jsx
+++ b/resources/js/components/StatusSummaryTable/NeedsUpdateLabel.jsx
@@ -23,7 +23,7 @@ const BADGE_STYLES = {
 };
 
 /**
- * Compact badge indicating crew status data is stale (18+ hours old).
+ * Compact badge indicating aircraft status data is stale (more than 18 hours old).
  */
 export function NeedsUpdateLabel({ size = 'lg', ...badgeProps }) {
     const iconSize = ICON_SIZE_BY_BADGE[size] ?? ICON_SIZE_BY_BADGE.sm;

--- a/resources/js/components/StatusSummaryTable/OnIncidentsLabel.jsx
+++ b/resources/js/components/StatusSummaryTable/OnIncidentsLabel.jsx
@@ -10,48 +10,79 @@ const ICON_SIZE_BY_BADGE = {
     xl: 20,
 };
 
+const ICON_ONLY_BADGE_STYLES = {
+    root: {
+        '--badge-border-width': '2px',
+        // Darken the light-variant text/icon for WCAG AA contrast on red tint
+        '--badge-color': 'var(--mantine-color-red-9)',
+        '--badge-bg': 'var(--mantine-color-red-1)',
+    },
+    label: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        lineHeight: 1,
+    },
+};
+
 /**
  * Tag-style label for personnel currently on staffed incidents.
  * Uses a dark fire-red on a light tint so text/icon stay readable.
+ * Omit `count` to render an icon-only key/legend badge.
  */
 export function OnIncidentsLabel({ count, size = 'lg', ...badgeProps }) {
-    const value = Number.parseInt(count, 10);
-    const safeCount = Number.isNaN(value) ? 0 : value;
+    const iconOnly = count === undefined || count === null;
+    const value = iconOnly ? null : Number.parseInt(count, 10);
+    const safeCount = value === null || Number.isNaN(value) ? 0 : value;
     const iconSize = ICON_SIZE_BY_BADGE[size] ?? ICON_SIZE_BY_BADGE.sm;
     const unit = safeCount === 1 ? 'person' : 'personnel';
+    const tooltipLabel = iconOnly
+        ? 'Personnel currently on incidents'
+        : `${safeCount} ${unit} currently on incidents`;
+    const ariaLabel = iconOnly
+        ? 'On incidents'
+        : `${safeCount} ${unit} on incidents`;
+
+    const icon = (
+        <PulaskiIcon
+            size={iconSize}
+            weight="bold"
+            aria-hidden
+            style={iconOnly ? { display: 'block' } : undefined}
+        />
+    );
 
     return (
-        <Tooltip
-            label={`${safeCount} ${unit} currently on incidents`}
-            withArrow
-            openDelay={200}
-        >
+        <Tooltip label={tooltipLabel} withArrow openDelay={200}>
             <Badge
                 variant="light"
                 color="red"
                 radius="sm"
                 size={size}
-                aria-label={`${safeCount} ${unit} on incidents`}
-                leftSection={
-                    <PulaskiIcon size={iconSize} weight="bold" aria-hidden />
-                }
+                aria-label={ariaLabel}
+                leftSection={iconOnly ? undefined : icon}
+                px={iconOnly ? 6 : undefined}
                 bd="2px solid var(--badge-color)"
-                styles={{
-                    root: {
-                        '--badge-border-width': '2px',
-                        // Darken the light-variant text/icon for WCAG AA contrast on red tint
-                        '--badge-color': 'var(--mantine-color-red-9)',
-                        '--badge-bg': 'var(--mantine-color-red-1)',
-                    },
-                    label: {
-                        minWidth: '2ch',
-                        textAlign: 'center',
-                        fontVariantNumeric: 'tabular-nums',
-                    },
-                }}
+                styles={
+                    iconOnly
+                        ? ICON_ONLY_BADGE_STYLES
+                        : {
+                              root: {
+                                  '--badge-border-width': '2px',
+                                  // Darken the light-variant text/icon for WCAG AA contrast on red tint
+                                  '--badge-color': 'var(--mantine-color-red-9)',
+                                  '--badge-bg': 'var(--mantine-color-red-1)',
+                              },
+                              label: {
+                                  minWidth: '2ch',
+                                  textAlign: 'center',
+                                  fontVariantNumeric: 'tabular-nums',
+                              },
+                          }
+                }
                 {...badgeProps}
             >
-                {safeCount}
+                {iconOnly ? icon : safeCount}
             </Badge>
         </Tooltip>
     );

--- a/resources/js/components/StatusSummaryTable/OnIncidentsLabel.jsx
+++ b/resources/js/components/StatusSummaryTable/OnIncidentsLabel.jsx
@@ -13,9 +13,6 @@ const ICON_SIZE_BY_BADGE = {
 const ICON_ONLY_BADGE_STYLES = {
     root: {
         '--badge-border-width': '2px',
-        // Darken the light-variant text/icon for WCAG AA contrast on red tint
-        '--badge-color': 'var(--mantine-color-red-9)',
-        '--badge-bg': 'var(--mantine-color-red-1)',
     },
     label: {
         display: 'inline-flex',
@@ -27,7 +24,6 @@ const ICON_ONLY_BADGE_STYLES = {
 
 /**
  * Tag-style label for personnel currently on staffed incidents.
- * Uses a dark fire-red on a light tint so text/icon stay readable.
  * Omit `count` to render an icon-only key/legend badge.
  */
 export function OnIncidentsLabel({ count, size = 'lg', ...badgeProps }) {
@@ -56,7 +52,7 @@ export function OnIncidentsLabel({ count, size = 'lg', ...badgeProps }) {
         <Tooltip label={tooltipLabel} withArrow openDelay={200}>
             <Badge
                 variant="light"
-                color="red"
+                color="blue"
                 radius="sm"
                 size={size}
                 aria-label={ariaLabel}
@@ -69,9 +65,6 @@ export function OnIncidentsLabel({ count, size = 'lg', ...badgeProps }) {
                         : {
                               root: {
                                   '--badge-border-width': '2px',
-                                  // Darken the light-variant text/icon for WCAG AA contrast on red tint
-                                  '--badge-color': 'var(--mantine-color-red-9)',
-                                  '--badge-bg': 'var(--mantine-color-red-1)',
                               },
                               label: {
                                   minWidth: '2ch',

--- a/resources/js/components/StatusSummaryTable/PersonnelCountLabel.jsx
+++ b/resources/js/components/StatusSummaryTable/PersonnelCountLabel.jsx
@@ -10,48 +10,70 @@ const ICON_SIZE_BY_BADGE = {
     xl: 20,
 };
 
+const ICON_ONLY_BADGE_STYLES = {
+    root: {
+        '--badge-border-width': '2px',
+    },
+    label: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        lineHeight: 1,
+    },
+};
+
 /**
  * Tag-style label for rappel personnel counts.
+ * Omit `count` to render an icon-only key/legend badge.
  */
 export function PersonnelCountLabel({ count, size = 'lg', ...badgeProps }) {
-    const value = Number.parseInt(count, 10);
-    const safeCount = Number.isNaN(value) ? 0 : value;
+    const iconOnly = count === undefined || count === null;
+    const value = iconOnly ? null : Number.parseInt(count, 10);
+    const safeCount = value === null || Number.isNaN(value) ? 0 : value;
     const iconSize = ICON_SIZE_BY_BADGE[size] ?? ICON_SIZE_BY_BADGE.sm;
     const unit = safeCount === 1 ? 'person' : 'personnel';
+    const tooltipLabel = iconOnly
+        ? 'Personnel currently staffing'
+        : `${safeCount} ${unit} currently staffing`;
+    const ariaLabel = iconOnly ? 'Staffing' : `${safeCount} ${unit}`;
+
+    const icon = (
+        <FlightHelmetIcon
+            size={iconSize}
+            weight="bold"
+            aria-hidden
+            style={iconOnly ? { display: 'block' } : undefined}
+        />
+    );
 
     return (
-        <Tooltip
-            label={`${safeCount} ${unit} currently staffing`}
-            withArrow
-            openDelay={200}
-        >
+        <Tooltip label={tooltipLabel} withArrow openDelay={200}>
             <Badge
                 variant="light"
                 color="blue"
                 radius="sm"
                 size={size}
-                aria-label={`${safeCount} ${unit}`}
-                leftSection={
-                    <FlightHelmetIcon
-                        size={iconSize}
-                        weight="bold"
-                        aria-hidden
-                    />
-                }
+                aria-label={ariaLabel}
+                leftSection={iconOnly ? undefined : icon}
+                px={iconOnly ? 6 : undefined}
                 bd="2px solid var(--badge-color)"
-                styles={{
-                    root: {
-                        '--badge-border-width': '2px',
-                    },
-                    label: {
-                        minWidth: '2ch',
-                        textAlign: 'center',
-                        fontVariantNumeric: 'tabular-nums',
-                    },
-                }}
+                styles={
+                    iconOnly
+                        ? ICON_ONLY_BADGE_STYLES
+                        : {
+                              root: {
+                                  '--badge-border-width': '2px',
+                              },
+                              label: {
+                                  minWidth: '2ch',
+                                  textAlign: 'center',
+                                  fontVariantNumeric: 'tabular-nums',
+                              },
+                          }
+                }
                 {...badgeProps}
             >
-                {safeCount}
+                {iconOnly ? icon : safeCount}
             </Badge>
         </Tooltip>
     );

--- a/resources/js/components/StatusSummaryTable/index.jsx
+++ b/resources/js/components/StatusSummaryTable/index.jsx
@@ -173,8 +173,16 @@ const SummaryTotals = ({ crews }) => {
         computeTotals(crews);
 
     const stats = [
-        { label: 'Staffing', value: totalStaffing },
-        { label: 'On incidents', value: totalPersonnelOnStaffedIncidents },
+        {
+            label: 'Staffing',
+            value: totalStaffing,
+            legend: <PersonnelCountLabel />,
+        },
+        {
+            label: 'On incidents',
+            value: totalPersonnelOnStaffedIncidents,
+            legend: <OnIncidentsLabel />,
+        },
         { label: 'Boosters in', value: totalBoosters },
     ];
 
@@ -182,9 +190,17 @@ const SummaryTotals = ({ crews }) => {
         <SimpleGrid cols={3} spacing="sm">
             {stats.map((stat) => (
                 <Paper key={stat.label} withBorder p="md" radius="md">
-                    <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
-                        {stat.label}
-                    </Text>
+                    <Group
+                        justify="space-between"
+                        align="flex-start"
+                        gap="xs"
+                        wrap="nowrap"
+                    >
+                        <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+                            {stat.label}
+                        </Text>
+                        {stat.legend ?? null}
+                    </Group>
                     <Text size="xl" fw={700} lh={1.2} mt={4}>
                         {stat.value}
                     </Text>
@@ -227,7 +243,7 @@ const StaffedIncidentList = ({ jsonString }) => {
                         align="flex-start"
                     >
                         {personnel !== '' && (
-                            <PersonnelCountLabel count={personnel} />
+                            <OnIncidentsLabel count={personnel} />
                         )}
                         <Box style={{ flex: 1, minWidth: 0 }}>
                             <Text size="sm" fw={500} lh={1.3}>

--- a/resources/js/components/StatusSummaryTable/index.jsx
+++ b/resources/js/components/StatusSummaryTable/index.jsx
@@ -15,11 +15,15 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import DutyOfficer from './DutyOfficer';
+import MechanicalProblemLabel from './MechanicalProblemLabel';
 import NeedsUpdateLabel from './NeedsUpdateLabel';
 import OnIncidentsLabel from './OnIncidentsLabel';
 import PersonnelCountLabel from './PersonnelCountLabel';
 import { isResourceStale } from './styles';
 import Timestamp from './Timestamp';
+
+/** Assignment value that indicates an aircraft has a mechanical problem. */
+const MECHANICAL_ASSIGNMENT = 'Unavailable: Mechanical';
 
 /** Shared column template so header + nested aircraft rows stay aligned. */
 const AIRCRAFT_GRID_COLUMNS = {
@@ -75,6 +79,13 @@ function boostersIn(resource) {
         return resource.getIn(['latest_status', 'staffing_value2'], '0');
     }
     return '';
+}
+
+function hasMechanicalProblem(resource) {
+    return (
+        resource.getIn(['latest_status', 'assigned_fire_name']) ===
+        MECHANICAL_ASSIGNMENT
+    );
 }
 
 function getCrewTotalStaffing(crewRow) {
@@ -297,6 +308,8 @@ const HelicopterCard = ({ resource }) => {
     const boosters = boostersIn(resource);
     const staffedIncidents = resource.getIn(['latest_status', 'comments1']);
     const hasSpotter = Boolean(managerName || managerPhone);
+    const stale = isResourceStale(resource);
+    const mechanical = hasMechanicalProblem(resource);
     const incidentsContent = hasStaffedIncidents(staffedIncidents) ? (
         <StaffedIncidentList jsonString={staffedIncidents} />
     ) : null;
@@ -307,22 +320,40 @@ const HelicopterCard = ({ resource }) => {
             radius="md"
             p="md"
             bg="var(--mantine-color-body)"
-            style={{ borderColor: 'var(--mantine-color-gray-3)' }}
+            style={{
+                borderColor: stale
+                    ? 'var(--mantine-color-yellow-6)'
+                    : 'var(--mantine-color-gray-3)',
+            }}
         >
             <Group justify="space-between" align="flex-start" mb="sm" gap="sm">
                 <Box>
-                    <Text fw={700} size="md" lh={1.2}>
+                    <Text
+                        fw={700}
+                        size="md"
+                        lh={1.2}
+                        fs={stale ? 'italic' : undefined}
+                        c={stale ? 'dimmed' : undefined}
+                    >
                         {identifier}
                     </Text>
                     {model && (
-                        <Text size="sm" c="dimmed">
+                        <Text
+                            size="sm"
+                            c="dimmed"
+                            fs={stale ? 'italic' : undefined}
+                        >
                             {model}
                         </Text>
                     )}
                 </Box>
-                {staffing !== '' && (
-                    <PersonnelCountLabel count={staffing} size="lg" />
-                )}
+                <Group gap={6} wrap="nowrap">
+                    {mechanical ? <MechanicalProblemLabel /> : null}
+                    {stale ? <NeedsUpdateLabel /> : null}
+                    {staffing !== '' && (
+                        <PersonnelCountLabel count={staffing} size="lg" />
+                    )}
+                </Group>
             </Group>
 
             {/* Fixed field order so sections stay in the same grid slot across aircraft */}
@@ -453,6 +484,14 @@ const AircraftOverviewRow = ({ resource }) => {
     const staffingCount = parseInt(staffing, 10);
     const safeStaffing = Number.isNaN(staffingCount) ? 0 : staffingCount;
     const stale = isResourceStale(resource);
+    const mechanical = hasMechanicalProblem(resource);
+
+    const renderStatusLabels = () => (
+        <>
+            {mechanical ? <MechanicalProblemLabel /> : null}
+            {stale ? <NeedsUpdateLabel /> : null}
+        </>
+    );
 
     return (
         <Box
@@ -484,7 +523,7 @@ const AircraftOverviewRow = ({ resource }) => {
                     </Text>
                 </Box>
                 <Group gap={6} wrap="nowrap" justify="flex-end">
-                    {stale ? <NeedsUpdateLabel /> : null}
+                    {renderStatusLabels()}
                     <PersonnelCountLabel count={safeStaffing} />
                 </Group>
             </Box>
@@ -498,9 +537,9 @@ const AircraftOverviewRow = ({ resource }) => {
                 <OverviewCell stale={stale}>{identifier}</OverviewCell>
                 <PersonnelCountLabel count={safeStaffing} />
                 <OverviewCell stale={stale}>{location}</OverviewCell>
-                <Box style={{ justifySelf: 'end' }}>
-                    {stale ? <NeedsUpdateLabel /> : null}
-                </Box>
+                <Group gap={6} wrap="nowrap" justify="flex-end">
+                    {renderStatusLabels()}
+                </Group>
             </Box>
 
             {/* Desktop */}
@@ -509,9 +548,9 @@ const AircraftOverviewRow = ({ resource }) => {
                 <PersonnelCountLabel count={safeStaffing} />
                 <OverviewCell stale={stale}>{location}</OverviewCell>
                 <OverviewCell stale={stale}>{assignment}</OverviewCell>
-                <Box style={{ justifySelf: 'end' }}>
-                    {stale ? <NeedsUpdateLabel /> : null}
-                </Box>
+                <Group gap={6} wrap="nowrap" justify="flex-end">
+                    {renderStatusLabels()}
+                </Group>
             </Box>
         </Box>
     );

--- a/resources/js/components/StatusSummaryTable/styles.js
+++ b/resources/js/components/StatusSummaryTable/styles.js
@@ -1,16 +1,7 @@
 import Moment from 'moment';
 
-/** Crew status is stale when last update was 18+ hours ago. */
-export const isCrewStale = (crewRow) =>
-    Boolean(
-        crewRow &&
-            Moment.utc(crewRow.get('updated_at'))
-                .add(18, 'hours')
-                .isSameOrBefore(Moment.now())
-    );
-
 /**
- * Aircraft status is stale when its latest status is 18+ hours old.
+ * Aircraft status is stale when its latest status is more than 18 hours old.
  * Uses created_at (matching PHP freshness), with updated_at as fallback.
  */
 export const isResourceStale = (resource) => {
@@ -26,7 +17,5 @@ export const isResourceStale = (resource) => {
         return true;
     }
 
-    return Moment.utc(timestamp)
-        .add(18, 'hours')
-        .isSameOrBefore(Moment.now());
+    return Moment.utc(timestamp).add(18, 'hours').isBefore(Moment.now());
 };

--- a/resources/views/status_forms/Helicopter.blade.php
+++ b/resources/views/status_forms/Helicopter.blade.php
@@ -90,6 +90,7 @@
                     <option value="Prepo" {{ $status->assigned_fire_name == 'Prepo' ? 'selected' : '' }}>Prepo</option>
                     <option value="Large Fire Support" {{ $status->assigned_fire_name == 'Large Fire Support' ? 'selected' : '' }}>Large Fire Support</option>
                     <option value="Project" {{ $status->assigned_fire_name == 'Project' ? 'selected' : '' }}>Project</option>
+                    <option value="Unavailable: Mechanical" {{ $status->assigned_fire_name == 'Unavailable: Mechanical' ? 'selected' : '' }}>Unavailable: Mechanical</option>
                     <option value="Other" {{ $status->assigned_fire_name == 'Other' ? 'selected' : '' }}>Other</option>
                 </select>
             </div>


### PR DESCRIPTION
Created a new aircraft assignment for "Unavailable: Mechanical"
A new status badge shows up on the summary page when an aircraft is unavailable as well.
Helicopters that are unavailable are shown on the map view with a red triangle.

<img width="953" height="756" alt="image" src="https://github.com/user-attachments/assets/b178cfcf-997a-4a73-8c08-a29879db3d1d" />


<img width="1187" height="207" alt="image" src="https://github.com/user-attachments/assets/5203b453-a7db-49c8-9687-75832c202788" />

<img width="765" height="851" alt="image" src="https://github.com/user-attachments/assets/8099aa4b-e761-455a-aa2d-131f149804db" />
