### PR TITLE
Personnel counts appear on each Aircraft row instead of each Crew row + input form fields resized to accommodate expected content

### DIFF
--- a/resources/js/components/StatusSummaryTable/MechanicalProblemLabel.jsx
+++ b/resources/js/components/StatusSummaryTable/MechanicalProblemLabel.jsx
@@ -16,6 +16,8 @@ const BADGE_STYLES = {
         // Darken the light-variant text/icon for WCAG AA contrast on red tint
         '--badge-color': 'var(--mantine-color-red-9)',
         '--badge-bg': 'var(--mantine-color-red-1)',
+        // Prevent flex parents from compressing the icon-only badge (overflow:hidden clips the icon)
+        flexShrink: 0,
     },
     label: {
         display: 'inline-flex',

--- a/resources/js/components/StatusSummaryTable/NeedsUpdateLabel.jsx
+++ b/resources/js/components/StatusSummaryTable/NeedsUpdateLabel.jsx
@@ -13,6 +13,8 @@ const ICON_SIZE_BY_BADGE = {
 const BADGE_STYLES = {
     root: {
         '--badge-border-width': '2px',
+        // Prevent flex parents from compressing the icon-only badge (overflow:hidden clips the icon)
+        flexShrink: 0,
     },
     label: {
         display: 'inline-flex',

--- a/resources/js/components/StatusSummaryTable/OnIncidentsLabel.jsx
+++ b/resources/js/components/StatusSummaryTable/OnIncidentsLabel.jsx
@@ -13,6 +13,8 @@ const ICON_SIZE_BY_BADGE = {
 const ICON_ONLY_BADGE_STYLES = {
     root: {
         '--badge-border-width': '2px',
+        // Prevent flex parents from compressing the icon-only badge (overflow:hidden clips the icon)
+        flexShrink: 0,
     },
     label: {
         display: 'inline-flex',
@@ -65,6 +67,7 @@ export function OnIncidentsLabel({ count, size = 'lg', ...badgeProps }) {
                         : {
                               root: {
                                   '--badge-border-width': '2px',
+                                  flexShrink: 0,
                               },
                               label: {
                                   minWidth: '2ch',

--- a/resources/js/components/StatusSummaryTable/OnIncidentsLabel.jsx
+++ b/resources/js/components/StatusSummaryTable/OnIncidentsLabel.jsx
@@ -59,7 +59,7 @@ export function OnIncidentsLabel({ count, size = 'lg', ...badgeProps }) {
                 size={size}
                 aria-label={ariaLabel}
                 leftSection={iconOnly ? undefined : icon}
-                px={iconOnly ? 6 : undefined}
+                px={6}
                 bd="2px solid var(--badge-color)"
                 styles={
                     iconOnly

--- a/resources/js/components/StatusSummaryTable/PersonnelCountLabel.jsx
+++ b/resources/js/components/StatusSummaryTable/PersonnelCountLabel.jsx
@@ -57,7 +57,7 @@ export function PersonnelCountLabel({ count, size = 'lg', ...badgeProps }) {
                 size={size}
                 aria-label={ariaLabel}
                 leftSection={iconOnly ? undefined : icon}
-                px={iconOnly ? 6 : undefined}
+                px={6}
                 bd="2px solid var(--badge-color)"
                 styles={
                     iconOnly

--- a/resources/js/components/StatusSummaryTable/PersonnelCountLabel.jsx
+++ b/resources/js/components/StatusSummaryTable/PersonnelCountLabel.jsx
@@ -13,6 +13,8 @@ const ICON_SIZE_BY_BADGE = {
 const ICON_ONLY_BADGE_STYLES = {
     root: {
         '--badge-border-width': '2px',
+        // Prevent flex parents from compressing the icon-only badge (overflow:hidden clips the icon)
+        flexShrink: 0,
     },
     label: {
         display: 'inline-flex',
@@ -63,6 +65,7 @@ export function PersonnelCountLabel({ count, size = 'lg', ...badgeProps }) {
                         : {
                               root: {
                                   '--badge-border-width': '2px',
+                                  flexShrink: 0,
                               },
                               label: {
                                   minWidth: '2ch',

--- a/resources/js/components/StatusSummaryTable/index.jsx
+++ b/resources/js/components/StatusSummaryTable/index.jsx
@@ -27,11 +27,16 @@ const MECHANICAL_ASSIGNMENT = 'Unavailable: Mechanical';
 
 /** Shared column template so header + nested aircraft rows stay aligned. */
 const AIRCRAFT_GRID_COLUMNS = {
-    base: 'minmax(0, 1fr) auto',
-    // Status column is `auto` so 1–2 icon badges keep their natural width.
-    sm: 'minmax(5rem, 1fr) 4.5rem minmax(0, 1.3fr) auto',
-    md: 'minmax(5rem, 1fr) 4.5rem minmax(0, 1.1fr) minmax(0, 1.2fr) auto',
+    // Fixed tracks for Staffing / On-incidents / Status so `1fr` columns
+    // compute identically on every row (an `auto` Status column shifts the
+    // badge columns when one row has status icons and another does not).
+    base: 'minmax(0, 1fr) 4.5rem 4.5rem 5rem',
+    sm: 'minmax(5rem, 1fr) 4.5rem 5.5rem minmax(0, 1.3fr) 5rem',
+    md: 'minmax(5rem, 1fr) 4.5rem 5.5rem minmax(0, 1.1fr) minmax(0, 1.2fr) 5rem',
 };
+
+/** Keep overview count badges the same width so 1- and 2-digit values align. */
+const OVERVIEW_COUNT_BADGE_PROPS = { w: '4.5rem' };
 
 const aircraftGridStyle = (breakpoint) => ({
     display: 'grid',
@@ -89,15 +94,6 @@ function hasMechanicalProblem(resource) {
     );
 }
 
-function getCrewTotalStaffing(crewRow) {
-    const resources = crewRow.get('statusable_resources') || fromJS([]);
-
-    return resources.reduce((total, resource) => {
-        const staffing = parseInt(staffingValues(resource), 10);
-        return Number.isNaN(staffing) ? total : total + staffing;
-    }, 0);
-}
-
 function getResourcePersonnelOnIncidents(resource) {
     const staffedIncidents = resource.getIn(['latest_status', 'comments1'], '');
     if (!staffedIncidents) {
@@ -118,15 +114,6 @@ function getResourcePersonnelOnIncidents(resource) {
             ? personnelTotal
             : personnelTotal + personnel;
     }, 0);
-}
-
-function getCrewTotalOnIncidents(crewRow) {
-    const resources = crewRow.get('statusable_resources') || fromJS([]);
-
-    return resources.reduce(
-        (total, resource) => total + getResourcePersonnelOnIncidents(resource),
-        0
-    );
 }
 
 function computeTotals(crews) {
@@ -455,6 +442,9 @@ const OverviewHeader = () => (
                 Staffing
             </Text>
             <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+                On incidents
+            </Text>
+            <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
                 Location
             </Text>
             <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
@@ -467,6 +457,9 @@ const OverviewHeader = () => (
             </Text>
             <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
                 Staffing
+            </Text>
+            <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+                On incidents
             </Text>
             <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
                 Location
@@ -489,6 +482,7 @@ const AircraftOverviewRow = ({ resource }) => {
     const staffing = staffingValues(resource);
     const staffingCount = parseInt(staffing, 10);
     const safeStaffing = Number.isNaN(staffingCount) ? 0 : staffingCount;
+    const onIncidents = getResourcePersonnelOnIncidents(resource);
     const stale = isResourceStale(resource);
     const mechanical = hasMechanicalProblem(resource);
 
@@ -528,9 +522,16 @@ const AircraftOverviewRow = ({ resource }) => {
                         {location}
                     </Text>
                 </Box>
+                <PersonnelCountLabel
+                    count={safeStaffing}
+                    {...OVERVIEW_COUNT_BADGE_PROPS}
+                />
+                <OnIncidentsLabel
+                    count={onIncidents}
+                    {...OVERVIEW_COUNT_BADGE_PROPS}
+                />
                 <Group gap={6} wrap="nowrap" justify="flex-end">
                     {renderStatusLabels()}
-                    <PersonnelCountLabel count={safeStaffing} />
                 </Group>
             </Box>
 
@@ -541,7 +542,14 @@ const AircraftOverviewRow = ({ resource }) => {
                 style={aircraftGridStyle('sm')}
             >
                 <OverviewCell stale={stale}>{identifier}</OverviewCell>
-                <PersonnelCountLabel count={safeStaffing} />
+                <PersonnelCountLabel
+                    count={safeStaffing}
+                    {...OVERVIEW_COUNT_BADGE_PROPS}
+                />
+                <OnIncidentsLabel
+                    count={onIncidents}
+                    {...OVERVIEW_COUNT_BADGE_PROPS}
+                />
                 <OverviewCell stale={stale}>{location}</OverviewCell>
                 <Group gap={6} wrap="nowrap" justify="flex-end">
                     {renderStatusLabels()}
@@ -551,7 +559,14 @@ const AircraftOverviewRow = ({ resource }) => {
             {/* Desktop */}
             <Box visibleFrom="md" style={aircraftGridStyle('md')}>
                 <OverviewCell stale={stale}>{identifier}</OverviewCell>
-                <PersonnelCountLabel count={safeStaffing} />
+                <PersonnelCountLabel
+                    count={safeStaffing}
+                    {...OVERVIEW_COUNT_BADGE_PROPS}
+                />
+                <OnIncidentsLabel
+                    count={onIncidents}
+                    {...OVERVIEW_COUNT_BADGE_PROPS}
+                />
                 <OverviewCell stale={stale}>{location}</OverviewCell>
                 <OverviewCell stale={stale}>{assignment}</OverviewCell>
                 <Group gap={6} wrap="nowrap" justify="flex-end">
@@ -572,8 +587,6 @@ const CrewRow = ({ crewRow, isExpanded, onToggle }) => {
     }
 
     const resources = crewRow.get('statusable_resources');
-    const totalStaffing = getCrewTotalStaffing(crewRow);
-    const totalOnIncidents = getCrewTotalOnIncidents(crewRow);
     const phone = crewRow.get('phone');
 
     return (
@@ -603,22 +616,11 @@ const CrewRow = ({ crewRow, isExpanded, onToggle }) => {
                     textAlign: 'left',
                 }}
             >
-                <Group
-                    justify="space-between"
-                    align="center"
-                    gap="sm"
-                    wrap="nowrap"
-                >
-                    <Group gap="sm" wrap="nowrap" style={{ minWidth: 0 }}>
-                        <ExpandIcon expanded={isExpanded} />
-                        <Text fw={700} size="sm" truncate="end">
-                            {crewRow.get('name')}
-                        </Text>
-                    </Group>
-                    <Group gap={6} wrap="nowrap">
-                        <PersonnelCountLabel count={totalStaffing || 0} />
-                        <OnIncidentsLabel count={totalOnIncidents || 0} />
-                    </Group>
+                <Group gap="sm" wrap="nowrap" style={{ minWidth: 0 }}>
+                    <ExpandIcon expanded={isExpanded} />
+                    <Text fw={700} size="sm" truncate="end">
+                        {crewRow.get('name')}
+                    </Text>
                 </Group>
 
                 {!isExpanded &&

--- a/resources/js/components/StatusSummaryTable/index.jsx
+++ b/resources/js/components/StatusSummaryTable/index.jsx
@@ -30,13 +30,13 @@ const AIRCRAFT_GRID_COLUMNS = {
     // Fixed tracks for Staffing / On-incidents / Status so `1fr` columns
     // compute identically on every row (an `auto` Status column shifts the
     // badge columns when one row has status icons and another does not).
-    base: 'minmax(0, 1fr) 4.5rem 4.5rem 5rem',
-    sm: 'minmax(5rem, 1fr) 4.5rem 5.5rem minmax(0, 1.3fr) 5rem',
-    md: 'minmax(5rem, 1fr) 4.5rem 5.5rem minmax(0, 1.1fr) minmax(0, 1.2fr) 5rem',
+    base: 'minmax(0, 1fr) 3.75rem 3.75rem 5rem',
+    sm: 'minmax(5rem, 1fr) 3.75rem 5.5rem minmax(0, 1.3fr) 5rem',
+    md: 'minmax(5rem, 1fr) 3.75rem 5.5rem minmax(0, 1.1fr) minmax(0, 1.2fr) 5rem',
 };
 
 /** Keep overview count badges the same width so 1- and 2-digit values align. */
-const OVERVIEW_COUNT_BADGE_PROPS = { w: '4.5rem' };
+const OVERVIEW_COUNT_BADGE_PROPS = { w: '3.75rem' };
 
 const aircraftGridStyle = (breakpoint) => ({
     display: 'grid',
@@ -206,9 +206,12 @@ const SummaryTotals = ({ crews }) => {
                             {stat.label}
                         </Text>
                     </Group>
-                    <Text size="xl" fw={700} lh={1.2} mt={4}>
-                        {stat.legend ?? null} {stat.value}
-                    </Text>
+                    <Group gap="xs" align="center" mt={4} wrap="nowrap">
+                        {stat.legend ?? null}
+                        <Text size="xl" fw={700} lh={1.2}>
+                            {stat.value}
+                        </Text>
+                    </Group>
                 </Paper>
             ))}
         </SimpleGrid>

--- a/resources/js/components/StatusSummaryTable/index.jsx
+++ b/resources/js/components/StatusSummaryTable/index.jsx
@@ -28,8 +28,9 @@ const MECHANICAL_ASSIGNMENT = 'Unavailable: Mechanical';
 /** Shared column template so header + nested aircraft rows stay aligned. */
 const AIRCRAFT_GRID_COLUMNS = {
     base: 'minmax(0, 1fr) auto',
-    sm: 'minmax(5rem, 1fr) 4.5rem minmax(0, 1.3fr) 2.5rem',
-    md: 'minmax(5rem, 1fr) 4.5rem minmax(0, 1.1fr) minmax(0, 1.2fr) 2.5rem',
+    // Status column is `auto` so 1–2 icon badges keep their natural width.
+    sm: 'minmax(5rem, 1fr) 4.5rem minmax(0, 1.3fr) auto',
+    md: 'minmax(5rem, 1fr) 4.5rem minmax(0, 1.1fr) minmax(0, 1.2fr) auto',
 };
 
 const aircraftGridStyle = (breakpoint) => ({
@@ -207,13 +208,19 @@ const SummaryTotals = ({ crews }) => {
                         gap="xs"
                         wrap="nowrap"
                     >
-                        <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+                        <Text
+                            size="xs"
+                            c="dimmed"
+                            tt="uppercase"
+                            fw={600}
+                            truncate="end"
+                            style={{ minWidth: 0 }}
+                        >
                             {stat.label}
                         </Text>
-                        {stat.legend ?? null}
                     </Group>
                     <Text size="xl" fw={700} lh={1.2} mt={4}>
-                        {stat.value}
+                        {stat.legend ?? null} {stat.value}
                     </Text>
                 </Paper>
             ))}
@@ -476,8 +483,7 @@ const OverviewHeader = () => (
 
 const AircraftOverviewRow = ({ resource }) => {
     const identifier = resource.get('identifier')?.toUpperCase() || '—';
-    const location =
-        resource.getIn(['latest_status', 'location_name']) || '—';
+    const location = resource.getIn(['latest_status', 'location_name']) || '—';
     const assignment =
         resource.getIn(['latest_status', 'assigned_fire_name']) || '—';
     const staffing = staffingValues(resource);

--- a/resources/sass/legacy-forms.scss
+++ b/resources/sass/legacy-forms.scss
@@ -451,6 +451,139 @@ textarea.form-control {
     line-height: 1;
 }
 
+// Staffed Incidents dynamic rows on helicopter status forms
+.staffed-incidents-rows {
+    // Shared column tracks so the header and every data row stay aligned.
+    // Personnel (2 digits) | Incident (OR-OCF-123456) | Est. Demob (MM/DD/YYYY) | delete
+    // Incident/demob mins include form-control horizontal padding (~1.5rem).
+    // Actions column is fixed to the delete button width (not `auto`) so an
+    // empty header cell doesn't collapse and shift the demob label right.
+    display: grid;
+    grid-template-columns:
+        4.5rem
+        minmax(calc(13ch + 1.5rem), 1fr)
+        minmax(calc(10ch + 1.5rem), 9.5rem)
+        2.75rem;
+    column-gap: 0.5rem;
+    row-gap: 0.5rem;
+    width: 100%;
+}
+
+.staffed-incidents-header,
+.staffed-incident-row {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+    align-items: end;
+}
+
+.staffed-incidents-header {
+    margin-bottom: -0.25rem;
+    text-align: left;
+
+    span {
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: $color-text-muted;
+        line-height: 1.2;
+        text-align: left;
+    }
+}
+
+.staffed-incident-field {
+    position: relative;
+    min-width: 0;
+}
+
+.staffed-incident-field-label {
+    // Visually hidden on desktop (header labels the columns); shown on mobile.
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.staffed-incident-personnel-col .form-control,
+.staffed-incident-name-col .form-control,
+.staffed-incident-demob-col .form-control {
+    width: 100%;
+    min-width: 0;
+}
+
+.staffed-incident-actions-col {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+
+    .btn {
+        padding-left: 0.55rem;
+        padding-right: 0.55rem;
+    }
+}
+
+@media (max-width: ($breakpoint-sm - 1px)) {
+    .staffed-incidents-rows {
+        display: block;
+    }
+
+    .staffed-incidents-header {
+        display: none;
+    }
+
+    .staffed-incident-row {
+        display: grid;
+        grid-column: auto;
+        grid-template-columns: 4.5rem minmax(0, 1fr) 2.75rem;
+        grid-template-areas:
+            'personnel name actions'
+            'demob demob demob';
+        column-gap: 0.5rem;
+        row-gap: 0.5rem;
+        align-items: start;
+        margin-bottom: 0.5rem;
+    }
+
+    .staffed-incident-personnel-col {
+        grid-area: personnel;
+    }
+
+    .staffed-incident-name-col {
+        grid-area: name;
+    }
+
+    .staffed-incident-demob-col {
+        grid-area: demob;
+    }
+
+    .staffed-incident-actions-col {
+        grid-area: actions;
+        align-items: flex-end;
+        padding-bottom: 0.15rem;
+        height: 100%;
+    }
+
+    .staffed-incident-field-label {
+        position: static;
+        width: auto;
+        height: auto;
+        margin: 0 0 0.2rem;
+        overflow: visible;
+        clip: auto;
+        white-space: normal;
+        display: block;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: $color-text-muted;
+        line-height: 1.2;
+    }
+}
+
 // Lat/Lon coordinate rows on status forms
 .latlon-form-group {
     align-items: flex-start !important;

--- a/resources/views/status_forms/Helicopter.blade.php
+++ b/resources/views/status_forms/Helicopter.blade.php
@@ -22,7 +22,7 @@
             <a role="button" class="control-label-helper" tabindex="0" data-toggle="popover" title="{{ $resource->staffingCategory1() }}" data-trigger="focus" data-content="{{ $resource->staffingCategory1Explanation() }}">
                 <span class="glyphicon glyphicon-question-sign"></span>
             </a>
-            <div class="col-xs-2 col-md-1">
+            <div class="col-xs-4 col-sm-2">
                 <input type="text" name="staffing_category1" id="staffing_category1" class="hidden" value="{{ $resource->staffingCategory1() }}">
                 <input type="text" name="staffing_value1" id="staffing_value1" class="form-control"  value="{{ $status->staffing_value1 }}">
             </div>

--- a/resources/views/status_forms/Helicopter.blade.php
+++ b/resources/views/status_forms/Helicopter.blade.php
@@ -122,7 +122,7 @@
             <a role="button" class="control-label-helper" tabindex="0" data-toggle="popover" title="Staffed Incidents" data-trigger="focus" data-content="i.e. MHF-355: Parker+3">
                 <span class="glyphicon glyphicon-question-sign"></span>
             </a>
-            <div class="col-xs-12 col-sm-6 col-md-6">
+            <div class="col-xs-12 col-sm-10 col-md-8">
                 <div class="staffed-incidents-rows">
                     <!-- Rows will be inserted here by JS -->
                 </div>
@@ -149,16 +149,64 @@
                             initialIncidents = [];
                         }
                     @endif
-                        
+
+                    function escapeAttr(value) {
+                        return value
+                            ? value.replace(/&/g, '&amp;').replace(/\"/g, '&quot;')
+                            : '';
+                    }
+
+                    function createStaffedIncidentHeader() {
+                        return `
+                            <div class="staffed-incidents-header" aria-hidden="true">
+                                <span class="staffed-incident-personnel-col">Personnel</span>
+                                <span class="staffed-incident-name-col">Incident</span>
+                                <span class="staffed-incident-demob-col">Est. Demob Date</span>
+                                <span class="staffed-incident-actions-col"></span>
+                            </div>
+                        `;
+                    }
+
                     function createStaffedIncidentRow(index, data = {}) {
                         return `
-                            <div class="staffed-incident-row" data-index="${index}" style="margin-bottom:8px; display: flex">
-                                    <input style="margin-right: 10px; width: 100px;" type="text" name="staffed_incidents[${index}][personnel]" class="form-control" placeholder="Personnel" value="${data.personnel ? data.personnel.replace(/&/g, '&amp;').replace(/\"/g, '&quot;') : ''}">
-                                    <input style="margin-right: 10px" type="text" name="staffed_incidents[${index}][incident_name]" class="form-control" placeholder="Incident Name/Number" value="${data.incident_name ? data.incident_name.replace(/&/g, '&amp;').replace(/\"/g, '&quot;') : ''}">
-                                    <input style="margin-right: 10px; width: 150px;" type="text" name="staffed_incidents[${index}][demob]" class="form-control" placeholder="Est. Demob Date" value="${data.demob ? data.demob.replace(/&/g, '&amp;').replace(/\"/g, '&quot;') : ''}">
-                                    <button type="button" class="btn btn-danger delete-staffed-incident-row">
+                            <div class="staffed-incident-row" data-index="${index}">
+                                <div class="staffed-incident-field staffed-incident-personnel-col">
+                                    <label class="staffed-incident-field-label" for="staffed_incidents_${index}_personnel">Personnel</label>
+                                    <input
+                                        id="staffed_incidents_${index}_personnel"
+                                        type="text"
+                                        inputmode="numeric"
+                                        name="staffed_incidents[${index}][personnel]"
+                                        class="form-control"
+                                        value="${escapeAttr(data.personnel)}"
+                                    >
+                                </div>
+                                <div class="staffed-incident-field staffed-incident-name-col">
+                                    <label class="staffed-incident-field-label" for="staffed_incidents_${index}_incident_name">Incident</label>
+                                    <input
+                                        id="staffed_incidents_${index}_incident_name"
+                                        type="text"
+                                        name="staffed_incidents[${index}][incident_name]"
+                                        class="form-control"
+                                        value="${escapeAttr(data.incident_name)}"
+                                    >
+                                </div>
+                                <div class="staffed-incident-field staffed-incident-demob-col">
+                                    <label class="staffed-incident-field-label" for="staffed_incidents_${index}_demob">Est. Demob Date</label>
+                                    <input
+                                        id="staffed_incidents_${index}_demob"
+                                        type="text"
+                                        name="staffed_incidents[${index}][demob]"
+                                        class="form-control"
+                                        placeholder="MM/DD/YYYY"
+                                        value="${escapeAttr(data.demob)}"
+                                    >
+                                </div>
+                                <div class="staffed-incident-actions-col">
+                                    <button type="button" class="btn btn-danger delete-staffed-incident-row" aria-label="Remove incident">
                                         <span class="glyphicon glyphicon-trash"></span>
                                     </button>
+                                </div>
                             </div>
                         `;
                     }
@@ -166,7 +214,7 @@
                     function renderStaffedIncidentRows(formInstance, incidents) {
                         const container = formInstance.querySelector('.staffed-incidents-rows');
                         // console.log('Rendering staffed incident rows:', incidents);
-                        container.innerHTML = '';
+                        container.innerHTML = createStaffedIncidentHeader();
                         incidents.forEach((row, idx) => {
                             container.innerHTML += createStaffedIncidentRow(idx, row);
                         });


### PR DESCRIPTION
1. Staffing numbers are moved to appear on each aircraft row instead of showing totals per crew:
<img width="913" height="711" alt="image" src="https://github.com/user-attachments/assets/2683883e-8b59-4bd8-82ef-61ba4a9298cd" />

2.  The "Staffed Incidents" input form is reformatted
<img width="619" height="141" alt="image" src="https://github.com/user-attachments/assets/0688e09c-ecec-43e2-b7c3-d25b774694ec" />

3. The "Staffing" input form field is wider to accommodate multiple characters
<img width="258" height="74" alt="image" src="https://github.com/user-attachments/assets/b0492ad9-8273-4cda-8be5-a210f7bafcdf" />
